### PR TITLE
Feature

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,31 @@ android {
     }
 
     buildTypes {
+        /** - Enables code shrinking, obfuscation, and optimization for only project's
+         *  release build type.
+         * We should always set minifyEnabled to true to decrease the size of our application
+         * and detect any code libraries that are not being used and ignore them from the final apk.
+
+         *- Includes the default ProGuard rules files that are packaged with the Android Gradle plugin
+         *  or we can configure our own proguard.
+         * it's better to enable proguard rules in our application project specifically on production build
+         * and we can add Retrofit, OkHttp, Gson, Models class to more secure for our application and
+         * preventing people from reverse engineering as following:-
+         release {
+
+         minifyEnabled true
+         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+         }
+         * our we can configure our own proguard rules instead of using the default google proguard
+         release {
+
+         minifyEnabled true
+         proguardFiles 'proguard-rules.pro'
+
+         }
+         *
+         * **/
         release {
             minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
@@ -34,6 +59,15 @@ android {
 }
 
 dependencies {
+    /**
+     * there is no module with a name (shoplist) so when running the project it gives an error
+     * on the project build that says the path could not be found in the project root.
+     * if we have modules we can implement them using the implement project otherwise
+     * it will give a path not found error on the project build **/
+
+    // commented because there is no module or path with the provided name on the root project
+    // implementation project(":shoplist")
+
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'
     implementation 'androidx.appcompat:appcompat:1.2.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,33 +19,8 @@ android {
     }
 
     buildTypes {
-        /** - Enables code shrinking, obfuscation, and optimization for only project's
-         *  release build type.
-         * We should always set minifyEnabled to true to decrease the size of our application
-         * and detect any code libraries that are not being used and ignore them from the final apk.
-
-         *- Includes the default ProGuard rules files that are packaged with the Android Gradle plugin
-         *  or we can configure our own proguard.
-         * it's better to enable proguard rules in our application project specifically on production build
-         * and we can add Retrofit, OkHttp, Gson, Models class to more secure for our application and
-         * preventing people from reverse engineering as following:-
-         release {
-
-         minifyEnabled true
-         proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-
-         }
-         * our we can configure our own proguard rules instead of using the default google proguard
-         release {
-
-         minifyEnabled true
-         proguardFiles 'proguard-rules.pro'
-
-         }
-         *
-         * **/
         release {
-            minifyEnabled true
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
@@ -59,14 +34,7 @@ android {
 }
 
 dependencies {
-    /**
-     * there is no module with a name (shoplist) so when running the project it gives an error
-     * on the project build that says the path could not be found in the project root.
-     * if we have modules we can implement them using the implement project otherwise
-     * it will give a path not found error on the project build **/
-
-    // commented because there is no module or path with the provided name on the root project
-    // implementation project(":shoplist")
+    implementation project(":shoplist")
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'

--- a/app/src/main/java/com/netguru/codereview/MainActivity.kt
+++ b/app/src/main/java/com/netguru/codereview/MainActivity.kt
@@ -1,11 +1,29 @@
 package com.netguru.codereview
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-
+import androidx.appcompat.app.AppCompatActivity
+//import com.netguru.codereview.ui.MainFragment
+// commented because there is no package with name ui and class with name MainFragment
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        /**
+         * To use the android navigation component, we should create an android resource
+         * file for our nav graph and configure the navigations
+         * There is no  package with the name ui to hold our MainFragment class.
+         * There is no fragment container with id container on activity_main file.
+
+        To fix these bugs we should do the following:-
+        - create a package with name ui
+        - create a fragment class with the name MainFragment
+        - add fragment container to the main activity
+         * and after that every things will be good otherwise it will lead to compilation error
+         * unresolved reference
+         * **/
+
+          //commented because it lead to compilation error
+         // supportFragmentManager.beginTransaction().replace(R.id.container, MainFragment()).commitNow()
     }
 }

--- a/app/src/main/java/com/netguru/codereview/MainActivity.kt
+++ b/app/src/main/java/com/netguru/codereview/MainActivity.kt
@@ -2,28 +2,12 @@ package com.netguru.codereview
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-//import com.netguru.codereview.ui.MainFragment
-// commented because there is no package with name ui and class with name MainFragment
+import com.netguru.codereview.ui.MainFragment
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        /**
-         * To use the android navigation component, we should create an android resource
-         * file for our nav graph and configure the navigations
-         * There is no  package with the name ui to hold our MainFragment class.
-         * There is no fragment container with id container on activity_main file.
-
-        To fix these bugs we should do the following:-
-        - create a package with name ui
-        - create a fragment class with the name MainFragment
-        - add fragment container to the main activity
-         * and after that every things will be good otherwise it will lead to compilation error
-         * unresolved reference
-         * **/
-
-          //commented because it lead to compilation error
-         // supportFragmentManager.beginTransaction().replace(R.id.container, MainFragment()).commitNow()
+          supportFragmentManager.beginTransaction().replace(R.id.container, MainFragment()).commitNow()
     }
 }


### PR DESCRIPTION
## First Issue

## Description
Remove fragment transaction on MainActivity class because there is no package with name ui and no fragment with name MainFragment, and remove the import of MainFragment class.

## Context

By commenting these lines of code the app will work fine and project will build successfully without errors, otherwise it will give compilation error unresolved references.
       
To use the android navigation component, we should create an android resource file for our nav graph and configure the navigations.
There is no  package with the name ui to hold our MainFragment class.
There is no fragment container with id container on activity_main file.

To fix these bugs we should do the following:-
- create a package with name ui
 - create a fragment class with the name MainFragment
 - add fragment container to the main activity and after that every things will be good otherwise it will lead to compilation error unresolved reference
         

## Checklist:

- [x] Commented the line of code where there are unresolved references.
- [x] Commented import where there is no package with name ui and class with name Mainfragment.


## Second Issue

## Description

Error detected on project build there is no path or module with name shoplist, minifyEnabled value is false on build type release.

## Context

By commenting the implementation project line of code the error will gone because there is no module with name shoplist in our project directory, and by setting the minifyEnabled to true we are enabling R8 configuration and proguard rules, code shrinking, obfuscation, and optimization in our project for more secure and preventing people form reverse engineering.

## Checklist:

- [x] Commented the line of code where there are implementation for module with name shoplist.
- [x] Change the value of minifyEnabled to true on release build type.



